### PR TITLE
Use Gradle 7.3

### DIFF
--- a/java-client-migration/gradle/wrapper/gradle-wrapper.properties
+++ b/java-client-migration/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 7.3 is the first gradle version officially supporting java 17 (LTS)
as mentioned at https://docs.gradle.org/current/userguide/compatibility.html