### PR TITLE
Add checksum to check gradle artifacts after downloading

### DIFF
--- a/java-client-migration/gradle/wrapper/gradle-wrapper.properties
+++ b/java-client-migration/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=de8f52ad49bdc759164f72439a3bf56ddb1589c4cde802d3cec7d6ad0e0ee410
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The PR adds `distributionSha256Sum` (checksum is taken from https://gradle.org/release-checksums/)