### PR TITLE
Upgrade Python Library

### DIFF
--- a/python-client-migration/requirements.txt
+++ b/python-client-migration/requirements.txt
@@ -1,3 +1,3 @@
-elasticsearch==7.13.1
+elasticsearch==7.13.4
 opensearch-py==1.0.0
 python-dotenv==0.19.2


### PR DESCRIPTION
According to the OpenSearch documentation,
the recommended version for the Python Elasticsearch
client should be 7.13.4

So this commit updates the version.