### PR TITLE
Fix elasticsearch

### DIFF
--- a/python-client-migration/requirements.txt
+++ b/python-client-migration/requirements.txt
@@ -1,3 +1,3 @@
-elasticsearch==7.13.4
+elasticsearch==7.10.2
 opensearch-py==1.0.0
 python-dotenv==0.19.2


### PR DESCRIPTION
Better to keep the elasticsearch version
similar to what is used in the other repository.

Tested and it is compatible. Also, it should be compatible
according to the OpenSearch version:
https://opensearch.org/docs/latest/clients/index/